### PR TITLE
make examples work from any subdirectory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2018"
 [dependencies]
 photon-rs = "0.3.0"
 perlin2d = "0.2.6"
+
+[dev-dependencies]
+project-root = "0.2.2"

--- a/examples/perlin_loop.rs
+++ b/examples/perlin_loop.rs
@@ -1,7 +1,11 @@
-use generative::canvas::Canvas;
-use generative::shape::shape2d::Polygon;
-use generative::Transform;
+use generative::{canvas::Canvas, shape::shape2d::Polygon, Transform};
 use perlin2d::PerlinNoise2D;
+
+fn path(relative: &str) -> String {
+    let mut path = project_root::get_project_root().unwrap();
+    path.push(relative);
+    path.to_str().unwrap().to_owned()
+}
 
 fn setup() -> Canvas {
     let mut canvas = Canvas::new(3840 * 2, 2160 * 2);
@@ -43,5 +47,5 @@ fn display(canvas: &mut Canvas) {
 fn main() {
     let mut ctx = setup();
     display(&mut ctx);
-    ctx.save_as_image("examples/outputs/perlin_loop.png");
+    ctx.save_as_image(&path("examples/outputs/perlin_loop.png"));
 }

--- a/examples/waveform_image.rs
+++ b/examples/waveform_image.rs
@@ -1,13 +1,17 @@
-use generative::canvas::Canvas;
-use generative::shape::shape2d::Line;
+use generative::{canvas::Canvas, shape::shape2d::Line};
 
+fn path(relative: &str) -> String {
+    let mut path = project_root::get_project_root().unwrap();
+    path.push(relative);
+    path.to_str().unwrap().to_owned()
+}
 fn setup() -> Canvas {
-    let mut canvas = Canvas::image_as_canvas("examples/inputs/animal.jpg");
+    let mut canvas = Canvas::image_as_canvas(&path("examples/inputs/animal.jpg"));
     canvas.fill((255, 255, 255, 255));
     canvas
 }
 fn display(canvas: &mut Canvas, amplitude: f32) {
-    let img = Canvas::image_as_canvas("examples/inputs/animal.jpg");
+    let img = Canvas::image_as_canvas(&path("examples/inputs/animal.jpg"));
     let width = canvas.get_width();
     let height = canvas.get_height();
     let mut y = 0_f32;
@@ -66,5 +70,5 @@ fn main() {
     let mut ctx = setup();
     let amplitude = 5.0;
     display(&mut ctx, amplitude);
-    ctx.save_as_image("examples/outputs/animal_wave.png");
+    ctx.save_as_image(&path("examples/outputs/animal_wave.png"));
 }


### PR DESCRIPTION
- add the `project-root` crate as a dev-dependency.
- add a `path` function to both examples that converts a relative path from the
  root of the project to a full path.
- use compact syntax for importing multiple types from the same crate.